### PR TITLE
Ck duplicate interest

### DIFF
--- a/src/algo/abe-support.cpp
+++ b/src/algo/abe-support.cpp
@@ -284,6 +284,11 @@ ABESupport::decrypt(oabe::OpenABECryptoContext& context, const PublicParams &pub
   }
 }
 
+void ABESupport::clearCachedContentKeys()
+{
+  m_decryptedContentKeyMap.clear();
+}
+
 } // namespace algo
 } // namespace nacabe
 } // namespace ndn

--- a/src/algo/abe-support.cpp
+++ b/src/algo/abe-support.cpp
@@ -239,22 +239,35 @@ ABESupport::decrypt(oabe::OpenABECryptoContext& context, const PublicParams &pub
         const PrivateKey &prvKey, CipherText cipherText)
 {
   try {
-    // step 0: set up ABE Context
-    context.importPublicParams(pubParams.m_pub);
-
-    // step 1: import prvKey into OpenABE
-    context.enableKeyManager("user1");
-    context.importUserKey("key1", prvKey.m_prv);
-
-    // step 2: cpDecrypt cipherText.aesKey, which is the encrypted symmetric key
+    // search in std::map<std::string, std::string> m_decryptedContentKeyMap for encryptedSymmetricKey and get the decrypted symmetric key and skip step 0,1,2 if exists
+    std::string decryptedSymmetricKey;
     std::string encryptedSymmetricKey(reinterpret_cast<char*>(cipherText.m_contentKey->m_encAesKey.data()));
-    bool result = context.decrypt(encryptedSymmetricKey, cipherText.m_contentKey->m_aesKey);
-    if (!result) {
-      BOOST_THROW_EXCEPTION(NacAlgoError("Decryption error!"));
+    auto it = m_decryptedContentKeyMap.find(encryptedSymmetricKey);
+    if (it != m_decryptedContentKeyMap.end()) {
+        // found in cache
+        decryptedSymmetricKey = m_decryptedContentKeyMap[encryptedSymmetricKey];
+    } else {
+        // step 0: set up ABE Context
+        context.importPublicParams(pubParams.m_pub);
+
+        // step 1: import prvKey into OpenABE
+        context.enableKeyManager("user1");
+        context.importUserKey("key1", prvKey.m_prv);
+
+        // step 2: cpDecrypt cipherText.aesKey, which is the encrypted symmetric key
+        // not found in cache, decrypt it and cache it
+        bool result = context.decrypt(encryptedSymmetricKey, cipherText.m_contentKey->m_aesKey);
+        if (!result)
+        {
+          BOOST_THROW_EXCEPTION(NacAlgoError("Decryption error!"));
+        }
+        // put the decrypted key in cache
+        m_decryptedContentKeyMap[encryptedSymmetricKey] = cipherText.m_contentKey->m_aesKey;
+        decryptedSymmetricKey = cipherText.m_contentKey->m_aesKey;
     }
 
     // step 3: use the decrypted symmetricKey to AES cpDecrypt cipherText.m_content
-    OpenABESymKeyEnc aes(cipherText.m_contentKey->m_aesKey);
+    OpenABESymKeyEnc aes(decryptedSymmetricKey);
     std::string cipherContentStr(reinterpret_cast<char*>(cipherText.m_content.data()));
     std::string recoveredContent = aes.decrypt(cipherContentStr);
 

--- a/src/algo/abe-support.hpp
+++ b/src/algo/abe-support.hpp
@@ -90,6 +90,8 @@ public:
   kpDecrypt(const PublicParams &pubParams,
             const PrivateKey &prvKey, CipherText cipherText);
 
+  void
+  clearCachedContentKeys();
 
 private:
   void

--- a/src/algo/abe-support.hpp
+++ b/src/algo/abe-support.hpp
@@ -110,6 +110,9 @@ private:
 private:
   static const char *SCHEMA_CPABE;
   static const char *SCHEMA_KPABE;
+  // cache the decrypted AES content key (std::string) in a map and use the encrypted AES content key as the key
+  std::map<std::string, std::string> m_decryptedContentKeyMap;
+
 
 private:
   ABESupport();

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -160,6 +160,20 @@ Consumer::consume(const Interest& dataInterest,
                                    dataCallback, errorCallback, nackMessage, timeoutMessage));
 }
 
+void 
+Consumer::consume(const Name &dataName,
+                  const Block &dataBlock,
+                  const ConsumptionCallback &consumptionCb,
+                  const ErrorCallback &errorCallback)
+{
+  // ready for decryption
+  if (!readyForDecryption()) {
+    errorCallback("Public params or private decryption key doesn't exist");
+    return;
+  }
+  decryptContent(dataName, dataBlock, consumptionCb, errorCallback);
+}
+
 void
 Consumer::setMaxRetries(int maxRetries)
 {

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -125,8 +125,10 @@ Consumer::consume(const Interest& dataInterest,
   auto dataCallback = [=] (const Interest&, const Data& data) {
     Name dataName = data.getName();
     // if segmentation
-    if (dataName.get(-1).isSegment()) {
-      auto fetcher = SegmentFetcher::start(m_face, dataInterest, m_validator);
+    if (dataName.get(-1).isSegment()) {  
+      ndn::SegmentFetcher::Options fetchOptions;
+      fetchOptions.probeLatestVersion = false; // Disable MustBeFresh flag
+      auto fetcher = SegmentFetcher::start(m_face, dataInterest, m_validator, fetchOptions);
       fetcher->afterSegmentValidated.connect([](Data seg) {
         NDN_LOG_DEBUG("Validated " << seg.getName());
       });
@@ -204,6 +206,26 @@ Consumer::decryptContent(const Name& dataObjName,
 
   Name ckName(content.get(tlv::Name));
   NDN_LOG_INFO("CK Name is " << ckName);
+
+  //if this CK's encrypted AES is cached, skip network and decrypt data
+  std::unordered_map<ndn::Name, ndn::Buffer>::const_iterator it = m_ckEncAesCache.find(ckName);
+  if (it != m_ckEncAesCache.end()) {
+    NDN_LOG_DEBUG("CK encAES cache hit for " << ckName);
+    cipherText->m_contentKey = std::make_shared<algo::ContentKey>();
+    cipherText->m_contentKey->m_encAesKey = it->second;
+    try {
+      Buffer result;
+      if (m_paramFetcher.getAbeType() == ABE_TYPE_CP_ABE)
+        result = algo::ABESupport::getInstance().cpDecrypt(m_paramFetcher.getPublicParams(), m_keyCache, *cipherText);
+      else if (m_paramFetcher.getAbeType() == ABE_TYPE_KP_ABE)
+        result = algo::ABESupport::getInstance().kpDecrypt(m_paramFetcher.getPublicParams(), m_keyCache, *cipherText);
+      else { errorCallback("Unsupported ABE type"); return; }
+      successCallBack(result);
+    }
+    catch (const std::exception& e) { errorCallback(e.what()); }
+    return;
+  }
+
   Interest ckInterest(ckName);
   ckInterest.setInterestLifetime(ndn::time::milliseconds(m_defaultTimeout));
   ckInterest.setCanBePrefix(true);
@@ -215,16 +237,47 @@ Consumer::decryptContent(const Name& dataObjName,
     Name dataName = data.getName();
     // if segmentation
     if (dataName.get(-1).isSegment()) {
-      auto fetcher = SegmentFetcher::start(m_face, ckInterest, m_validator);
+      ndn::SegmentFetcher::Options fetchOptions;
+      fetchOptions.probeLatestVersion = false; // Disable MustBeFresh flag
+      auto fetcher = SegmentFetcher::start(m_face, ckInterest, m_validator, fetchOptions);
+
       fetcher->afterSegmentValidated.connect([](Data seg) {
         NDN_LOG_DEBUG("Validated " << seg.getName());
       });
       fetcher->onComplete.connect([=] (ConstBufferPtr contentBuffer) {
         NDN_LOG_DEBUG("SegmentFetcher completed with total fetched size of " << contentBuffer->size());
-        onCkeyData(dataName.getPrefix(-1), Block(contentBuffer), cipherText, successCallBack, errorCallback);
+        Name ckObjName = dataName.getPrefix(-1);
+        Block ckBlock(contentBuffer);
+        // Cache encrypted AES so future data with same CK skip the network entirely
+        try {
+          ckBlock.parse();
+          Block encTLV = ckBlock.get(TLV_EncryptedAesKey);
+          m_ckEncAesCache[ckObjName] = Buffer(encTLV.value(), encTLV.value_size());
+        }
+        catch (const std::exception& e) {
+              NDN_LOG_WARN("CK cache fill skipped: " << e.what());
+            } 
+        // complete all queued tasks  waiting on this CK remove from pending callback or ck sent
+        auto it = m_pendingCallbacks.find(ckName);
+        if (it != m_pendingCallbacks.end()) {
+           for (const auto& t : it->second) {
+              onCkeyData(ckObjName, ckBlock, t.cipher, t.onSuccess, t.onError);
+           }
+          m_pendingCallbacks.erase(it);
+        }
+        m_ckInterestsSent.erase(ckName);
       });
-      fetcher->onError.connect([] (uint32_t errorCode, const std::string& errorMsg) {
-        NDN_LOG_ERROR("Error occurs in segment fetching: " << errorMsg);
+      //send error for each data
+      fetcher->onError.connect([this, ckName] (uint32_t errorCode, const std::string& errorMsg) {
+        NDN_LOG_ERROR("Error occurs in segment fetching decrypt content: " << errorMsg);
+        auto it = m_pendingCallbacks.find(ckName);
+        if (it != m_pendingCallbacks.end()) {
+         for (const auto& t : it->second) {
+          if (t.onError) t.onError(errorMsg);
+          }
+          m_pendingCallbacks.erase(it);
+        }
+        m_ckInterestsSent.erase(ckName);
       });
     }
     // if no segmentation
@@ -232,7 +285,26 @@ Consumer::decryptContent(const Name& dataObjName,
       m_validator.validate(data,
         [=] (const Data& data) {
           NDN_LOG_INFO("Content key conforms to trust schema");
-          onCkeyData(data.getName(), data.getContent(), cipherText, successCallBack, errorCallback);
+          Name ckObjName = data.getName();
+          Block ckBlock = data.getContent();
+          // Cache encrypted AES for decrypt later
+          try {
+            ckBlock.parse();
+            Block encTLV = ckBlock.get(TLV_EncryptedAesKey);
+            m_ckEncAesCache[ckObjName] = Buffer(encTLV.value(), encTLV.value_size());
+          }
+          catch (const std::exception& e) {
+              NDN_LOG_WARN("CK cache fill skipped: " << e.what());
+            }
+          // complete all queued tasks for this CK
+          auto it = m_pendingCallbacks.find(ckName);
+          if (it != m_pendingCallbacks.end()) {
+            for (const auto& t : it->second) {
+              onCkeyData(ckObjName, ckBlock, t.cipher, t.onSuccess, t.onError);
+            }
+            m_pendingCallbacks.erase(it);
+          }
+          m_ckInterestsSent.erase(ckName);
         },
         [] (auto&&, const ndn::security::ValidationError& error) {
           NDN_THROW(std::runtime_error("Fetched content key cannot be authenticated: " + error.getInfo()));
@@ -241,14 +313,37 @@ Consumer::decryptContent(const Name& dataObjName,
     }
   };
 
-  // probe segmentation
-  NDN_LOG_INFO(m_cert.getIdentity() << " Ask for data " << ckInterest.getName());
-  m_face.expressInterest(ckInterest,
-                         dataCallback,
-                         std::bind(&Consumer::handleNack, this, _1, _2, errorCallback, nackMessage),
-                         std::bind(&Consumer::handleTimeout, this, _1, m_maxRetries,
-                                   dataCallback, errorCallback, nackMessage, timeoutMessage));
+  //Only one CK Interest at a time, queue everyone else behind
+  if (m_ckInterestsSent.count(ckName) == 0) {
+    m_ckInterestsSent.insert(ckName);
+    m_pendingCallbacks[ckName].push_back(PendingTask{cipherText, successCallBack, errorCallback});
+
+    // Wrap errors so all queued ck are notified
+    ErrorCallback broadcastErr = [this, ckName, errorCallback] (const std::string& msg) {
+      errorCallback(msg);
+      auto it = m_pendingCallbacks.find(ckName);
+      if (it != m_pendingCallbacks.end()) {
+        for (const auto& t : it->second) {
+          if (t.onError) t.onError(msg);
+        }
+        m_pendingCallbacks.erase(it);
+      }
+      m_ckInterestsSent.erase(ckName);
+    };
+
+    NDN_LOG_INFO(m_cert.getIdentity() << " Ask for data " << ckInterest.getName() );
+    m_face.expressInterest(ckInterest,
+                           dataCallback,
+                           std::bind(&Consumer::handleNack, this, _1, _2, broadcastErr, nackMessage),
+                           std::bind(&Consumer::handleTimeout, this, _1, m_maxRetries,
+                                     dataCallback, broadcastErr, nackMessage, timeoutMessage));
+  }
+  else {
+    NDN_LOG_DEBUG("CK interest already sent for " << ckName);
+    m_pendingCallbacks[ckName].push_back(PendingTask{cipherText, successCallBack, errorCallback});
+  }
 }
+
 
 void
 Consumer::onCkeyData(const Name& ckObjName, const Block& content,

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -125,7 +125,7 @@ Consumer::consume(const Interest& dataInterest,
   auto dataCallback = [=] (const Interest&, const Data& data) {
     Name dataName = data.getName();
     // if segmentation
-    if (dataName.get(-1).isSegment()) {  
+    if (dataName.get(-1).isSegment()) {
       ndn::SegmentFetcher::Options fetchOptions;
       fetchOptions.probeLatestVersion = false; // Disable MustBeFresh flag
       auto fetcher = SegmentFetcher::start(m_face, dataInterest, m_validator, fetchOptions);
@@ -330,7 +330,7 @@ Consumer::decryptContent(const Name& dataObjName,
       }
       m_ckInterestsSent.erase(ckName);
     };
-
+    // probe segmentation
     NDN_LOG_INFO(m_cert.getIdentity() << " Ask for data " << ckInterest.getName() );
     m_face.expressInterest(ckInterest,
                            dataCallback,
@@ -343,7 +343,6 @@ Consumer::decryptContent(const Name& dataObjName,
     m_pendingCallbacks[ckName].push_back(PendingTask{cipherText, successCallBack, errorCallback});
   }
 }
-
 
 void
 Consumer::onCkeyData(const Name& ckObjName, const Block& content,

--- a/src/consumer.hpp
+++ b/src/consumer.hpp
@@ -87,6 +87,23 @@ public:
           const ErrorCallback& errorCallback);
 
   /**
+   * @brief Consume an encrypted data block
+   *
+   * The function will directly use the dataBlock to retrive the CK.
+   * After decrypting CK with cached DKEY, the CK will be used to cpDecrypt the data packet.
+   *
+   * @param dataName The packet name.
+   * @param Block Its type is ndn::tlv::content
+   * @param consumptionCb The success callback.
+   * @param errorCallback The failure callback.
+   */
+  void
+  consume(const Name& dataName,
+          const Block& dataBlock,
+          const ConsumptionCallback& consumptionCb,
+          const ErrorCallback& errorCallback);  
+
+  /**
    * @brief Set the maximum number of retries for fetching data packets.
    * @param maxRetries The maximum number of retries.
   */

--- a/src/consumer.hpp
+++ b/src/consumer.hpp
@@ -101,7 +101,7 @@ public:
   consume(const Name& dataName,
           const Block& dataBlock,
           const ConsumptionCallback& consumptionCb,
-          const ErrorCallback& errorCallback);  
+          const ErrorCallback& errorCallback); 
 
   /**
    * @brief Set the maximum number of retries for fetching data packets.
@@ -149,6 +149,16 @@ private:
 
   TrustConfig m_trustConfig;
   algo::PrivateKey m_keyCache;
+
+  struct PendingTask {
+    std::shared_ptr<algo::CipherText> cipher;
+    ConsumptionCallback onSuccess;
+    ErrorCallback onError;
+  };
+
+  std::unordered_set<ndn::Name> m_ckInterestsSent;
+  std::unordered_map<ndn::Name, std::vector<PendingTask>> m_pendingCallbacks;
+  std::unordered_map<ndn::Name, ndn::Buffer> m_ckEncAesCache;
 
   int m_maxRetries = 3;
   int m_defaultTimeout = 200;

--- a/src/consumer.hpp
+++ b/src/consumer.hpp
@@ -101,7 +101,7 @@ public:
   consume(const Name& dataName,
           const Block& dataBlock,
           const ConsumptionCallback& consumptionCb,
-          const ErrorCallback& errorCallback); 
+          const ErrorCallback& errorCallback);  
 
   /**
    * @brief Set the maximum number of retries for fetching data packets.

--- a/src/param-fetcher.hpp
+++ b/src/param-fetcher.hpp
@@ -70,6 +70,8 @@ private:
   security::Validator& m_validator;
   const Name& m_attrAuthorityPrefix;
   const TrustConfig& m_trustConfig;
+  int m_retryCount = 0;
+  const int MAX_RETRIES = 10;
 
 PUBLIC_WITH_TESTS_ELSE_PRIVATE:
   AbeType m_abeType;

--- a/tests/unit-tests/abe-support.t.cpp
+++ b/tests/unit-tests/abe-support.t.cpp
@@ -118,6 +118,7 @@ BOOST_AUTO_TEST_CASE(CpEncryptionDecryption)
   BOOST_CHECK_EQUAL_COLLECTIONS(result4.begin(), result4.end(), random1024, random1024 + sizeof(random1024));
 
   // encryption/decryption test case 5: access forbidden
+  ABESupport::getInstance().clearCachedContentKeys();
   std::vector<std::string> wrongKeyAttrList = { "mit", "professor" };
   auto anotherPrvKey = ABESupport::getInstance().cpPrvKeyGen(pubParams, masterKey, wrongKeyAttrList);
   // cannot decrypt because of the wrong decryption key attribute set

--- a/tests/unit-tests/integrated-test.t.cpp
+++ b/tests/unit-tests/integrated-test.t.cpp
@@ -23,6 +23,7 @@
 #include "data-owner.hpp"
 #include "producer.hpp"
 #include "cache-producer.hpp"
+#include "algo/abe-support.hpp"
 
 #include "test-common.hpp"
 
@@ -236,6 +237,7 @@ BOOST_AUTO_TEST_CASE(Cp)
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 
+  ndn::nacabe::algo::ABESupport::getInstance().clearCachedContentKeys();
   isConsumeCbCalled = false;
   consumer2.obtainDecryptionKey();
   advanceClocks(time::milliseconds(20), 60);
@@ -386,6 +388,7 @@ BOOST_AUTO_TEST_CASE(Kp)
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 
+  ndn::nacabe::algo::ABESupport::getInstance().clearCachedContentKeys();
   isConsumeCbCalled = false;
   consumer2.obtainDecryptionKey();
   advanceClocks(time::milliseconds(20), 60);
@@ -536,6 +539,7 @@ BOOST_AUTO_TEST_CASE(KpCache)
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 
+  ndn::nacabe::algo::ABESupport::getInstance().clearCachedContentKeys();
   isConsumeCbCalled = false;
   consumer2.obtainDecryptionKey();
   advanceClocks(time::milliseconds(20), 60);


### PR DESCRIPTION
The changes are as follows:
Prevent duplicate CK fetches: track CK Interests and send only one Interest per CK
Local CK cache: add a CK-name -> encrypted-AES cache so later packets with the same CK don’t send a new Interest
Error broadcast: in case NACKs/timeouts/fetch error is returned to all data decrypt requests waiting on that CK
Fetcher option: probeLatestVersion = false so CKs can be fetched from repo storage (no MustBeFresh).

